### PR TITLE
Add CNAME file to ensure that new publish will not remove custom domain

### DIFF
--- a/docs/.vuepress/public/CNAME
+++ b/docs/.vuepress/public/CNAME
@@ -1,0 +1,1 @@
+kyoss.dev


### PR DESCRIPTION
Adding this CNAME file to the `public` folder will ensure that the GitHub pages custom domain doesn't get reset on every publish run in Actions.