### PR TITLE
update Presentation section (post-meeting)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,11 +26,16 @@ Systems](https://www.teksystems.com/).
 
 ## Presentations
 
-Our next meeting on July 13th, 2022 will feature the following presentations:
+Presentations for our next meeting on August 10th, 2022 have not yet been decided, but will be announced soon!
+
+Our last meeting on July 13th, 2022 featured the following presentations:
 
 1 - Remastering Debian (Ben Fitzpatrick)
 
 2 - The System76 Launch Keyboard (William Lindley)
+
+3 - Experiencing Southeast Linuxfest (Liang Yan)
+
 
 ## Links
 


### PR DESCRIPTION
This is an update to the Presentations section to reflect yesterday's meeting. I figured the section can acknowledge that the next meeting's presentations haven't been decided yet, then mention the presentations given during the last meeting.

I tried my best to do this PR by the book (appropriately branched, one commit). I really need to nail down Git.

Respectfully,

J. Stelly